### PR TITLE
Feature: up to date support for filtering files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,17 @@
-target
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# IDE's
 .settings
 .classpath
 .project
 *.iml
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: java
+script: mvn verify -B
 jdk:
  - oraclejdk8
  - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+---
+language: java
+jdk:
+ - oraclejdk8
+ - oraclejdk7
+ - openjdk7
+ - openjdk6

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2013 Codehaus
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2013 Codehaus
+   Copyright 2013 MojoHaus
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,182 @@
+Templating Maven Plugin
+=======================
+
+The templating maven plugin handles copying files from a source to a given output directory, while filtering them. This plugin is useful to filter Java Source Code if you need for example to have things in that code replaced with some properties values.
+
+Goals Overview
+--------------
+* `templating:filter-sources` lets you filter your sources in one go.
+* `templating:filter-test-sources` lets you filter your test sources in one go.
+
+Usage
+-----
+
+```xml
+<plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>templating-maven-plugin</artifactId>
+    <version>1.0-alpha-3</version>
+    <executions>
+        <execution>
+            <goals>
+                <goal>filter-sources</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
+General instructions on how to use the Templating Plugin can be found on the usage page. Some more specific use cases are described in the examples given below.
+
+In case you still have questions regarding the plugin's usage, please have a look at the FAQ and feel free to contact the user mailing list. The posts to the mailing list are archived and could already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching the mail archive.
+
+If you feel like the plugin is missing a feature or has a defect, you can fill a feature request or bug report in our issue tracker. When creating a new issue, please provide a comprehensive description of your concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason, entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated. Of course, patches are welcome, too. Contributors can check out the project from our source repository and will find supplementary information in the guide to helping with Maven.
+
+Examples
+--------
+
+The following examples show how to use the Templating Plugin in more advanced usecases:
+
+### How to typically configure the filtering ###
+
+The Templating Maven Plugin **filter-sources** goal lets you filter a dedicated source folder. In one pass, it filters that folder and adds the resulting filtered folder to the POM model as a source folder.
+
+If, for example, you have some of your code where you would like to reference properties coming from the POM, you want to put those classes inside the `sourceDirectory` tag.
+
+> Please note that filtering the standard `src/main/java` folder is not supported.
+
+```xml
+<project>
+...
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.5</version>
+        <executions>
+          <execution>
+            <id>filter-src</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+                <configuration>              
+                  <!-- 
+                    Note the two following parameters are the default one. 
+                    These are specified here just as a reminder. 
+                    But as the Maven philosophy is strongly about conventions, 
+                    it's better to just not specify them.
+                  -->
+                  <sourceDirectory>${basedir}/src/main/java-templates</sourceDirectory>
+                  <outputDirectory>${project.build.directory}/generated-sources/java-templates</outputDirectory>
+                </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+```
+
+### Specifying a character encoding scheme ###
+
+A character encoding scheme such as `ASCII`, `UTF-8` or `UTF-16` can be chosen to be used for the reading and writing of files.
+
+For example, if we want to specify that the character encoding scheme be `UTF-8`, we would simply have to configure that as in the following example:
+
+```xml
+<project>
+  ...
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.5</version>
+      </plugin>
+    </plugins>
+    ...
+  </build>
+  ...
+</project>
+```
+
+Goals Description
+-----------------
+
+### templating:filter-sources ###
+
+#### Full name: ####
+
+`org.codehaus.mojo:templating-maven-plugin:1.0.5:filter-sources`
+
+#### Description: ####
+
+This mojo helps adding a filtered source folder in one go. This is typically useful if you want to use properties coming from the POM inside parts of your source code that requires real constants, like annotations for example.
+
+#### Attributes: ####
+
+* Requires a Maven project to be executed.
+* The goal is thread-safe and supports parallel builds.
+* Binds by default to the *lifecycle* phase: `generate-sources`.
+
+#### Optional Parameters ####
+
+ Name       |  Type       | Description
+:-----------|:------------|:------------
+ delimiters | `List`      | Set of delimiters for expressions to filter within the resources. These delimiters are specified in the form 'beginToken\*endToken'. If no '\*' is given, the delimiter is assumed to be the same for start and end. So, the default filtering delimiters might be specified as: ```<delimiters> <delimiter>${*}</delimiter>  <delimiter>@</delimiter> </delimiters>```
+ | |Since the '@' delimiter is the same on both ends, we don't need to specify '@*@' (though we can).
+ encoding     | `String`      |    The character encoding scheme to be applied when filtering resources. 
+ ||**Default value is:** `${project.build.sourceEncoding}`. 
+escapeString  |  `String`    | Expression preceded with the String won't be interpolated `\${foo}` will be replaced with `${foo}`
+||**User property is:** `maven.resources.escapeString`.
+outputDirectory  |  `File` | Output folder where filtered sources will land.
+|| **Default value is:** `${project.build.directory}/generated-sources/java-templates`.
+sourceDirectory	| `File` | Source directory that will be first filtered and then added as a classical source folder.
+|| **Default value is:** `${basedir}/src/main/java-templates`.
+useDefaultDelimiters | `boolean`	| Controls whether the default delimiters are included in addition to those configured delimiters. Does not have any effect if delimiters is empty when the defaults will be included anyway.
+|| **Default value is:** `true`.
+
+### templating:filter-test-sources ###
+
+#### Full name: ####
+
+`org.codehaus.mojo:templating-maven-plugin:1.0.5:filter-test-sources`
+
+#### Description: ####
+
+This mojo helps adding a filtered source folder in one go. This is typically useful if you want to use properties coming from the POM inside parts of your test source code that requires real constants, like annotations for example.
+
+#### Attributes: ####
+
+* Requires a Maven project to be executed.
+* The goal is thread-safe and supports parallel builds.
+* Binds by default to the *lifecycle* phase: `generate-test-sources`.
+
+
+#### Optional Parameters ####
+
+ Name       |  Type       | Description
+:-----------|:------------|:------------
+ delimiters | `List`      | Set of delimiters for expressions to filter within the resources. These delimiters are specified in the form 'beginToken\*endToken'. If no '\*' is given, the delimiter is assumed to be the same for start and end. So, the default filtering delimiters might be specified as: ```<delimiters> <delimiter>${*}</delimiter>  <delimiter>@</delimiter> </delimiters>```
+ | |Since the '@' delimiter is the same on both ends, we don't need to specify '@*@' (though we can).
+ encoding     | `String`      |    The character encoding scheme to be applied when filtering resources. 
+ ||**Default value is:** `${project.build.sourceEncoding}`. 
+escapeString  |  `String`    | Expression preceded with the String won't be interpolated `\${foo}` will be replaced with `${foo}`
+||**User property is:** `maven.resources.escapeString`.
+testOutputDirectory  |  `File` | Output folder where filtered sources will land.
+|| **Default value is:** `${project.build.directory}/generated-sources/java-templates`.
+testSourceDirectory    | `File` | Source directory that will be first filtered and then added as a classical source folder.
+|| **Default value is:** `${basedir}/src/main/java-templates`.
+useDefaultDelimiters | `boolean`	| Controls whether the default delimiters are included in addition to those configured delimiters. Does not have any effect if delimiters is empty when the defaults will be included anyway.
+|| **Default value is:** `true`.
+
+
+Technical details
+-----------------
+Currently, it uses the Maven Filtering shared component for filtering resources and uses up-to-date mechanism.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Templating Maven Plugin
 =======================
 
+[![Build Status](https://travis-ci.org/mojohaus/templating-maven-plugin.svg)](https://travis-ci.org/mojohaus/templating-maven-plugin)
+
 The templating maven plugin handles copying files from a source to a given output directory, while filtering them. This plugin is useful to filter Java Source Code if you need for example to have things in that code replaced with some properties values.
 
 Goals Overview

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If, for example, you have some of your code where you would like to reference pr
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
-        <version>1.0.5</version>
+        <version>1.0-alpha-3</version>
         <executions>
           <execution>
             <id>filter-src</id>
@@ -99,7 +99,7 @@ For example, if we want to specify that the character encoding scheme be `UTF-8`
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>templating-maven-plugin</artifactId>
-        <version>1.0.5</version>
+        <version>1.0-alpha-3</version>
       </plugin>
     </plugins>
     ...
@@ -115,7 +115,7 @@ Goals Description
 
 #### Full name: ####
 
-`org.codehaus.mojo:templating-maven-plugin:1.0.5:filter-sources`
+`org.codehaus.mojo:templating-maven-plugin:1.0-alpha-3:filter-sources`
 
 #### Description: ####
 
@@ -148,7 +148,7 @@ useDefaultDelimiters | `boolean`	| Controls whether the default delimiters are i
 
 #### Full name: ####
 
-`org.codehaus.mojo:templating-maven-plugin:1.0.5:filter-test-sources`
+`org.codehaus.mojo:templating-maven-plugin:1.0-alpha-3:filter-test-sources`
 
 #### Description: ####
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
     <maven>${mavenVersion}</maven>
   </prerequisites>
   <scm>
-    <connection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/templating-maven-plugin</connection>
-    <developerConnection>scm:svn:https://svn.codehaus.org/mojo/trunk/mojo/templating-maven-plugin</developerConnection>
-    <url>http://fisheye.codehaus.org/browse/mojo/trunk/mojo/templating-maven-plugin</url>
+    <connection>scm:git:https://github.com/mojohaus/templating-maven-plugin</connection>
+    <developerConnection>scm:git:git@github.com:mojohaus/templating-maven-plugin.git</developerConnection>
+    <url>https://github.com/mojohaus/templating-maven-plugin</url>
   </scm>
   <properties>
     <mavenVersion>2.2.1</mavenVersion>

--- a/src/main/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojo.java
+++ b/src/main/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojo.java
@@ -14,12 +14,6 @@ package org.codehaus.mojo.templating;
  * the License.
  */
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
@@ -30,11 +24,22 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
+import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.plexus.build.incremental.BuildContext;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.zip.CRC32;
 
 public abstract class AbstractFilterSourcesMojo
     extends AbstractMojo
 {
+    private static final int CHECKSUM_BUFFER = 4096;
+    private int copied = 0;
+
     protected abstract File getSourceDirectory();
 
     protected abstract File getOutputDirectory();
@@ -84,6 +89,18 @@ public abstract class AbstractFilterSourcesMojo
     @Parameter( defaultValue = "${project}", required = true, readonly = true )
     protected MavenProject project;
 
+    /**
+     * Controls whether to overwrite files that are not changed, by default files will not be overwritten
+     */
+    @Parameter( defaultValue = "false" )
+    protected boolean overwrite;
+
+    /**
+     * Skips POM projects if set to true, which is the default option.
+     */
+    @Parameter( defaultValue = "true" )
+    protected boolean skipPoms;
+
     @Component( hint = "default" )
     protected MavenResourcesFiltering mavenResourcesFiltering;
 
@@ -91,29 +108,99 @@ public abstract class AbstractFilterSourcesMojo
         throws MojoExecutionException
     {
         File sourceDirectory = getSourceDirectory();
-        getLog().debug( "source=" + sourceDirectory + " target=" + getOutputDirectory() );
-
-        if ( !( sourceDirectory != null && sourceDirectory.exists() ) )
+        if ( !preconditionsFulfilled( sourceDirectory ) )
         {
-            getLog().info( "Request to add '" + sourceDirectory + "' folder. Not added since it does not exist." );
             return;
         }
-
         buildContext.removeMessages( sourceDirectory );
 
-        // 1 Copy with filtering the given source to target dir
+        // 1 Copy with filtering the given source to temporary dir
+        copied = 0;
+        File temporaryDirectory = getTemporaryDirectory( sourceDirectory );
+        logInfo( "Coping files with filtering to temporary directory." );
+        logDebug( "Temporary director for filtering is: %s", temporaryDirectory );
+        filterSourceToTemporaryDir( sourceDirectory, temporaryDirectory );
+        // 2 Copy if needed
+        copyDirectoryStructure( temporaryDirectory, getOutputDirectory(), getOutputDirectory() );
+        cleanupTemporaryDirectory( temporaryDirectory );
+        if ( isSomethingBeenUpdated() )
+        {
+            buildContext.refresh( getOutputDirectory() );
+            logInfo( "Copied %d files to output directory: %s", copied, getOutputDirectory() );
+        }
+        else
+        {
+            logInfo( "No files needs to be copied to output directory. Up to date: %s", getOutputDirectory() );
+        }
+
+        // 3 Add that dir to sources
+        addSourceFolderToProject( this.project );
+        logInfo( "Source directory: %s added.", getOutputDirectory() );
+    }
+
+    private void logInfo( String format, Object... args )
+    {
+        if ( getLog().isInfoEnabled() )
+        {
+            getLog().info( String.format( format, args ) );
+        }
+    }
+
+    private void logDebug( String format, Object... args )
+    {
+        if ( getLog().isDebugEnabled() )
+        {
+            getLog().debug( String.format( format, args ) );
+        }
+    }
+
+    private boolean isSomethingBeenUpdated()
+    {
+        return copied > 0;
+    }
+
+    private void cleanupTemporaryDirectory( File temporaryDirectory ) throws MojoExecutionException
+    {
+        try
+        {
+            FileUtils.forceDelete( temporaryDirectory );
+        }
+        catch ( IOException ex )
+        {
+            throw new MojoExecutionException( ex.getMessage(), ex );
+        }
+    }
+
+    private void filterSourceToTemporaryDir( final File sourceDirectory, final File temporaryDirectory )
+            throws MojoExecutionException
+    {
         List<Resource> resources = new ArrayList<Resource>();
         Resource resource = new Resource();
         resource.setFiltering( true );
-        getLog().debug( sourceDirectory.getAbsolutePath() );
+        logDebug( "Source absolute path: %s", sourceDirectory.getAbsolutePath() );
         resource.setDirectory( sourceDirectory.getAbsolutePath() );
         resources.add( resource );
 
         MavenResourcesExecution mavenResourcesExecution =
-            new MavenResourcesExecution( resources, getOutputDirectory(), project, encoding,
-                                         Collections.<String> emptyList(), Collections.<String> emptyList(), session );
+                new MavenResourcesExecution( resources, temporaryDirectory, project, encoding,
+                        Collections.<String>emptyList(), Collections.<String>emptyList(), session );
         mavenResourcesExecution.setInjectProjectBuildFilters( true );
         mavenResourcesExecution.setEscapeString( escapeString );
+        mavenResourcesExecution.setOverwrite( overwrite );
+        setDelimitersForExecution( mavenResourcesExecution );
+        try
+        {
+            mavenResourcesFiltering.filterResources( mavenResourcesExecution );
+        }
+        catch ( MavenFilteringException e )
+        {
+            buildContext.addMessage( getSourceDirectory(), 1, 1, "Filtering Exception", BuildContext.SEVERITY_ERROR, e );
+            throw new MojoExecutionException( e.getMessage(), e );
+        }
+    }
+
+    private void setDelimitersForExecution( MavenResourcesExecution mavenResourcesExecution )
+    {
         // if these are NOT set, just use the defaults, which are '${*}' and '@'.
         if ( delimiters != null && !delimiters.isEmpty() )
         {
@@ -138,26 +225,181 @@ public abstract class AbstractFilterSourcesMojo
 
             mavenResourcesExecution.setDelimiters( delims );
         }
+    }
 
+    private void preconditionsCopyDirectoryStructure( final File sourceDirectory, final File destinationDirectory,
+                                                      final File rootDestinationDirectory ) throws IOException
+    {
+        if ( sourceDirectory == null )
+        {
+            throw new IOException( "source directory can't be null." );
+        }
+
+        if ( destinationDirectory == null )
+        {
+            throw new IOException( "destination directory can't be null." );
+        }
+
+        if ( sourceDirectory.equals( destinationDirectory ) )
+        {
+            throw new IOException( "source and destination are the same directory." );
+        }
+
+        if ( !sourceDirectory.exists() )
+        {
+            throw new IOException( "Source directory doesn't exists (" + sourceDirectory.getAbsolutePath() + ")." );
+        }
+    }
+
+    private void copyDirectoryStructure( final File sourceDirectory, final File destinationDirectory,
+                                         final File rootDestinationDirectory ) throws MojoExecutionException
+    {
         try
         {
-            mavenResourcesFiltering.filterResources( mavenResourcesExecution );
+            copyDirectoryStructureWithIO( sourceDirectory, destinationDirectory, rootDestinationDirectory );
         }
-        catch ( MavenFilteringException e )
+        catch ( IOException ex )
         {
-            buildContext.addMessage( getSourceDirectory(), 1, 1, "Filtering Exception", BuildContext.SEVERITY_ERROR, e );
+            throw new MojoExecutionException( ex.getMessage(), ex );
+        }
+    }
+
+    private void copyDirectoryStructureWithIO( final File sourceDirectory, final File destinationDirectory,
+                                               final File rootDestinationDirectory ) throws IOException
+    {
+        preconditionsCopyDirectoryStructure( sourceDirectory, destinationDirectory, rootDestinationDirectory );
+        File[] files = sourceDirectory.listFiles();
+        if ( files == null )
+        {
+            return;
+        }
+        String sourcePath = sourceDirectory.getAbsolutePath();
+
+        for ( File file : files )
+        {
+            if ( file.equals( rootDestinationDirectory ) )
+            {
+                // We don't copy the destination directory in itself
+                continue;
+            }
+
+            String dest = file.getAbsolutePath();
+
+            dest = dest.substring( sourcePath.length() + 1 );
+
+            File destination = new File( destinationDirectory, dest );
+
+            if ( file.isFile() )
+            {
+                destination = destination.getParentFile();
+
+                if ( isFileDifferent( file, destination ) )
+                {
+                    copied++;
+                    FileUtils.copyFileToDirectory( file, destination );
+                }
+            }
+            else if ( file.isDirectory() )
+            {
+                if ( !destination.exists() && !destination.mkdirs() )
+                {
+                    throw new IOException(
+                            "Could not create destination directory '" + destination.getAbsolutePath() + "'." );
+                }
+
+                copyDirectoryStructureWithIO( file, destination, rootDestinationDirectory );
+            }
+            else
+            {
+                throw new IOException( "Unknown file type: " + file.getAbsolutePath() );
+            }
+        }
+    }
+
+    private File resolve( final File file, final String... subfile )
+    {
+        StringBuilder path = new StringBuilder();
+        path.append( file.getPath() );
+        for ( String fi : subfile )
+        {
+            path.append( File.separator );
+            path.append( fi );
+        }
+        return new File( path.toString() );
+    }
+
+    private boolean isFileDifferent( final File file, final File directory ) throws IOException
+    {
+        File targetFile = resolve( directory, file.getName() ).getAbsoluteFile();
+        return !targetFile.canRead() || getCrc32OfFile( file ) != getCrc32OfFile( targetFile );
+    }
+
+    private long getCrc32OfFile( final File target ) throws IOException
+    {
+        FileInputStream fis = null;
+        try
+        {
+            fis = new FileInputStream( target );
+            CRC32 crcMaker = new CRC32();
+            byte[] buffer = new byte[CHECKSUM_BUFFER];
+            int bytesRead;
+            while ( ( bytesRead = fis.read( buffer ) ) != -1 )
+            {
+                crcMaker.update( buffer, 0, bytesRead );
+            }
+            return crcMaker.getValue();
+        }
+        catch ( FileNotFoundException ex )
+        {
+            close( fis );
+            throw new IOException( ex.getLocalizedMessage(), ex );
+        }
+        finally
+        {
+            close( fis );
+        }
+    }
+
+    private void close( Closeable is ) throws IOException
+    {
+        if ( is != null )
+        {
+            is.close();
+        }
+    }
+
+    private File getTemporaryDirectory( File sourceDirectory ) throws MojoExecutionException
+    {
+        try
+        {
+            File basedir = project.getBasedir().getCanonicalFile();
+            String target = project.getBuild().getDirectory();
+            StringBuilder label = new StringBuilder( "templates-tmp" );
+            CRC32 crcMaker = new CRC32();
+            crcMaker.update( sourceDirectory.getCanonicalPath().getBytes() );
+            label.append( crcMaker.getValue() );
+            return resolve( basedir, target, label.toString() );
+        }
+        catch ( IOException e )
+        {
             throw new MojoExecutionException( e.getMessage(), e );
         }
+    }
 
-        // 2 Add that dir to sources
-        addSourceFolderToProject( this.project );
-
-        if ( getLog().isInfoEnabled() )
+    private boolean preconditionsFulfilled( File sourceDirectory )
+    {
+        if ( skipPoms && "pom".equals( project.getPackaging() ) )
         {
-            getLog().info( "Source directory: " + getOutputDirectory() + " added." );
+            logInfo( "Skipping a POM project type. Change a `skipPoms` to false to run anyway." );
+            return false;
         }
-        
-        buildContext.refresh( getOutputDirectory() );
+        logDebug( "source=%s target=%s", sourceDirectory, getOutputDirectory() );
+        if ( !( sourceDirectory != null && sourceDirectory.exists() ) )
+        {
+            logInfo( "Request to add '%s' folder. Not added since it does not exist.", sourceDirectory );
+            return false;
+        }
+        return true;
     }
 
     protected abstract void addSourceFolderToProject( MavenProject mavenProject );


### PR DESCRIPTION
I've added support to check files before writing. This is CRITICAL if you heavily use this plugin and your incremental builds (with `mvn verify`, without `clean` phase) needs to be as fast as possible.

Because maven as most build tools uses modification times for produced artifacts it is crucial to take care in overwriting files. This could lead to avalanche of other plugins to take unnecessary work.

For example: You change single file in project and execute a `mvn verify`. What happens is `templating-maven-plugin` will overwrite all files in generated sources changing only theirs modification times, which causes jars to repackage, war to repackage, ears to repackage... And so on. This is costly.

My approch was to perform filtering in temporary directory first and then copy files to their destination only if they are diffrent by content. Those changes are in this commit: 8a64812

As a bonus I've:
 * configured CI build with Travis
 * Add README.md for github
 * Add Apache 2.0 LICENSE file
 * Corrected Maven SCM settings
 * Added more entries to gitignore