### PR TITLE
Update mockito-core dependency to fix test errors

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,3 +27,7 @@ jobs:
       ff-maven: "3.9.2"                     # Maven version for fail-fast-build
       maven-matrix: '[ "3.2.5", "3.9.2" ]'  # Maven versions matrix for verify builds
       verify-fail-fast: false               # Fail-fast for verify builds
+      matrix-exclude: >
+        [
+          {"jdk": "8"}
+        ]

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.12.4</version>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
With mockito 3.12.4, you may get weird errors when running junit code (File.exists throwing NullPointerException, etc.)

Update dependency version to the latest available, 5.4.0.