### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ buildNumber.properties
 .project
 *.iml
 .idea
+.factorypath
+*~


### PR DESCRIPTION
.factorypath is a file that is generated by Eclipse for annotation processing.

Files ending with ~ are backup files created by certain editors.