### PR TITLE
Use forward-slash instead of File.separator for resource URLs

### DIFF
--- a/src/test/java/org/codehaus/mojo/templating/MavenProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/templating/MavenProjectStub.java
@@ -97,7 +97,7 @@ public class MavenProjectStub
 
     public static MavenProject createProjectForITExample( String exampleName )
     {
-        String load = exampleName + File.separator + "pom.xml";
+        String load = exampleName + '/' + "pom.xml";
         URL pomUrl = MavenProjectStub.class.getClassLoader().getResource( load );
         assert pomUrl != null : "Could not load: " + load;
         String pomPath = pomUrl.getPath();


### PR DESCRIPTION
Previously, we were calling getClassLoader().getResource(String) with a path that used File.separator. Since getResource expects a URL, this is incorrect, and, unfortunately, fails on Windows, where File.separator incidentally isn't a forward slash.

Fix the code to always use a forward slash here.