### PR TITLE
Update maven-filtering dependency; replace deprecated FileUtils methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
   <properties>
     <mavenVersion>3.2.5</mavenVersion>
     <mojo.java.target>8</mojo.java.target>
-    <mavenFilteringVersion>3.1.1</mavenFilteringVersion>
+    <mavenFilteringVersion>3.3.1</mavenFilteringVersion>
     <scmpublish.content>target/staging/${project.artifactId}</scmpublish.content>
   </properties>
 

--- a/src/test/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojoTest.java
@@ -20,17 +20,21 @@ package org.codehaus.mojo.templating;
  */
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesExecution;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
-import org.apache.maven.shared.utils.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,11 +44,6 @@ import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
@@ -76,7 +75,7 @@ public class AbstractFilterSourcesMojoTest
         throws IOException
     {
         File target = resolve( project.getBasedir(), outputDirectory.getPath() );
-        FileUtils.forceDelete( target );
+        FileUtils.deleteQuietly( target );
     }
 
     @Test
@@ -135,7 +134,7 @@ public class AbstractFilterSourcesMojoTest
             assertThat( source ).isDirectory();
             File destination = arg.getOutputDirectory();
             assertThat( destination ).doesNotExist();
-            FileUtils.copyDirectoryStructure( source, destination );
+            FileUtils.copyDirectory( source, destination );
             return null;
         }
     }

--- a/src/test/java/org/codehaus/mojo/templating/MavenProjectStub.java
+++ b/src/test/java/org/codehaus/mojo/templating/MavenProjectStub.java
@@ -26,11 +26,11 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.io.input.XmlStreamReader;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.utils.ReaderFactory;
 
 /**
  * @author Krzysztof Suszyński <krzysztof.suszynski@wavesoftware.pl>
@@ -60,9 +60,9 @@ public class MavenProjectStub
     {
         MavenXpp3Reader pomReader = new MavenXpp3Reader();
         Model model;
-        try
+        try ( XmlStreamReader in = new XmlStreamReader( new File( getBasedir(), "pom.xml" ) ) )
         {
-            model = pomReader.read( ReaderFactory.newXmlReader( new File( getBasedir(), "pom.xml" ) ) );
+            model = pomReader.read(in);
             setModel( model );
         }
         catch ( Exception e )


### PR DESCRIPTION
Update maven-filtering to 3.3.1.

Replace maven-shared-utils' FileUtils calls by commons-io FileUtils, as shown in deprecation markings.