### PR TITLE
Add missing @Override statements; remove unnecessary import

### DIFF
--- a/src/main/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojo.java
+++ b/src/main/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojo.java
@@ -123,6 +123,7 @@ public abstract class AbstractFilterSourcesMojo
     protected MavenResourcesFiltering mavenResourcesFiltering;
 
     /** {@inheritDoc} */
+    @Override
     public void execute()
         throws MojoExecutionException
     {

--- a/src/test/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/templating/AbstractFilterSourcesMojoTest.java
@@ -125,6 +125,7 @@ public class AbstractFilterSourcesMojoTest
         implements Answer<Void>
     {
 
+        @Override
         public Void answer( InvocationOnMock invocation )
             throws Throwable
         {

--- a/src/test/java/org/codehaus/mojo/templating/FailingFilterSourcesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/templating/FailingFilterSourcesMojoTest.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
This removes three warnings I see in Eclipse.